### PR TITLE
Compatibility with python3 before 3.5 (PEP 448)

### DIFF
--- a/optmark.py
+++ b/optmark.py
@@ -7,11 +7,15 @@ import getopt
 
 
 def read_passes(tree):
+    """
+    Recursively flatten JSON tree of passes into a single dictionary,
+    mapping from pass ids to pass names
+    """
     result = {}
     for e in tree:
         result[e['id']] = e['name']
         if 'children' in e:
-            result = { **result, **read_passes(e['children']) }
+            result.update(read_passes(e['children']))
     return result
 
 


### PR DESCRIPTION
read_passes currently requires Python 3.5 or later, due to
its use of `**` for dictionary unpacking within a "dictionary
display".  The generalization of the `**` syntax was added
in Python 3.5 via:
  https://www.python.org/dev/peps/pep-0448/

This patch avoids this syntax by using dict.update, and adds a docstring
to the function (to ensure that I got the meaning correct).